### PR TITLE
rebrand: Update README for TestMu AI rebranding

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,9 @@ Whether you have been part of the LambdaTest community for years or are just dis
 
 We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
-**Explore TestMu AI**
+👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
+
+**🔭 Explore TestMu AI**
 
 The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
 
@@ -194,8 +196,6 @@ The same infrastructure LambdaTest customers relied on, now delivered through au
 - [Real Device Cloud](https://www.testmuai.com/real-device-cloud/)
 - [Pricing](https://www.testmuai.com/pricing/)
 - [Documentation](https://www.testmuai.com/support/docs/)
-
-👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
 
 ## We are here to help you :headphones:
 

--- a/README.md
+++ b/README.md
@@ -1,38 +1,40 @@
-# Run Selenium Tests With Karma Test Runner On LambdaTest
+# Run Selenium Tests With Karma Test Runner — TestMu AI (Formerly LambdaTest)
 
 ![JavaScript](https://user-images.githubusercontent.com/95698164/172134732-2e9c780e-10ac-4956-b366-86ffc25bf070.png)
 
 <p align="center">
-  <a href="https://www.lambdatest.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample" target="_bank">Blog</a>
+  <a href="https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample" target="_bank">Blog</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample" target="_bank">Docs</a>
+  <a href="https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample" target="_bank">Docs</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample" target="_bank">Learning Hub</a>
+  <a href="https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample" target="_bank">Learning Hub</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/newsletter/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample" target="_bank">Newsletter</a>
+  <a href="https://www.testmuai.com/newsletter/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample" target="_bank">Newsletter</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/certifications/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample" target="_bank">Certifications</a>
+  <a href="https://www.testmuai.com/certifications/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample" target="_bank">Certifications</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.youtube.com/c/LambdaTest" target="_bank">YouTube</a>
+  <a href="https://www.youtube.com/@TestMuAI" target="_bank">YouTube</a>
 </p>
 &emsp;
 &emsp;
 &emsp;
 
-*Learn how to use Karma Test Runner framework to configure and run your JavaScript automation testing scripts on the LambdaTest platform*
+*Learn how to use Karma Test Runner framework to configure and run your JavaScript automation testing scripts on the TestMu AI platform*
 
 [<img height="58" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">](https://accounts.lambdatest.com/register)
+
 
 ## Table Of Contents
 
 * [Pre-requisites](#pre-requisites)
-* [Configuring LambdaTest tunnel To Run Karma Tests With LambdaTest](#configuring-lambdatest-tunnel-to-run-karma-tests-with-lambdatest)
-* [Integrating Your Karma Testing Framework With LambdaTest](#integrating-your-karma-testing-framework-with-lambdatest)
+* [Configuring TestMu AI tunnel To Run Karma Tests With TestMu AI](#configuring-lambdatest-tunnel-to-run-karma-tests-with-lambdatest)
+* [Integrating Your Karma Testing Framework With TestMu AI](#integrating-your-karma-testing-framework-with-lambdatest)
 * [Avoid Timeouts With psuedoActivityInterval](#avoid-timeouts-with-psuedoactivityinterval)
+
 
 ## Pre-requisites
 
-In order to perform tests with LambdaTest using Karma testing framework, you would need the below things to be already set up:
+In order to perform tests with TestMu AI using Karma testing framework, you would need the below things to be already set up:
 
 **1. Global Dependencies**
 * Make sure to use the latest version of JavaScript.
@@ -51,9 +53,9 @@ To install node.js with homebrew use the below command.
 `$ npm install -g @angular/cli`
 
 
-**2. LambdaTest Authentication Credentials**
+**2. TestMu AI Authentication Credentials**
 
-Be aware of your LambdaTest authentication credentials i.e. your LambdaTest username, access key and HubURL. You need to set them up as your environment variables. You can retrieve them from your [LambdaTest automation dashboard](https://automation.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample) by clicking on the key icon near the help button.
+Be aware of your TestMu AI authentication credentials i.e. your TestMu AI username, access key and HubURL. You need to set them up as your environment variables. You can retrieve them from your [TestMu AI automation dashboard](https://automation.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample) by clicking on the key icon near the help button.
 
 ```
 Start tunnel with command from the configure tunnel in your dashboard
@@ -75,7 +77,7 @@ export LT_TUNNEL=”TUNNEL NAME”
 
 ### Setting Up
 
-Clone the sample project from LambdaTest GitHub repository by using the below command in your cmd/terminal.
+Clone the sample project from TestMu AI GitHub repository by using the below command in your cmd/terminal.
 
 `git clone https://github.com/LambdaTest/angular-karma-sample && cd angular-karma-sample`
 
@@ -86,29 +88,31 @@ Install the node.js dependencies and Karma CLI globally using the below command.
 > **Change Browsers & Framework For Sample Project:**
 > If you wish to add more browsers or change the framework to something other than the one used in our Sample project then you can do so by editing the browser array/ framework array in the *karma.conf.js* file.
 
-## Configuring LambdaTest tunnel To Run Karma Tests With LambdaTest
 
-To help you perform cross browser testing of your locally stored web pages, LambdaTest provides an SSH(Secure Shell) tunnel connection with the name LambdaTest tunnel. With LambdaTest tunnel, you can execute a test your local Karma tests on cloud for performing automated cross browser testing on more than 2000 browsers offered by Selenium Grid on LambdaTest. So you make sure how well your changes look, even before your customers. Curious to know more about LambdaTest tunnel?
+## Configuring TestMu AI tunnel To Run Karma Tests With TestMu AI
 
-> Follow our documentation on LambdaTest tunnel to know it all. OS specific instructions to download and setup tunnel binary can be found at the following links.
+To help you perform cross browser testing of your locally stored web pages, TestMu AI provides an SSH(Secure Shell) tunnel connection with the name TestMu AI tunnel. With TestMu AI tunnel, you can execute a test your local Karma tests on cloud for performing automated cross browser testing on more than 2000 browsers offered by Selenium Grid on TestMu AI. So you make sure how well your changes look, even before your customers. Curious to know more about TestMu AI tunnel?
+
+> Follow our documentation on TestMu AI tunnel to know it all. OS specific instructions to download and setup tunnel binary can be found at the following links.
  * [Documentation For Windows User](/docs/local-testing-for-windows/)
  * [Documentation For Mac User](/docs/local-testing-for-macos/)
  * [Documentation For Linux User](/docs/local-testing-for-linux/)
 
 > Download the binary file of:
- * [LambdaTest tunnel for Windows](https://downloads.lambdatest.com/tunnel/v3/windows/64bit/LT_Windows.zip)
- * [LambdaTest tunnel for Mac](https://downloads.lambdatest.com/tunnel/v3/mac/64bit/LT_Mac.zip)
- * [LambdaTest tunnel for Linux](https://downloads.lambdatest.com/tunnel/v3/linux/64bit/LT_Linux.zip)
+ * [TestMu AI tunnel for Windows](https://downloads.lambdatest.com/tunnel/v3/windows/64bit/LT_Windows.zip)
+ * [TestMu AI tunnel for Mac](https://downloads.lambdatest.com/tunnel/v3/mac/64bit/LT_Mac.zip)
+ * [TestMu AI tunnel for Linux](https://downloads.lambdatest.com/tunnel/v3/linux/64bit/LT_Linux.zip)
 
 Once, the tunnel is successfully set up. You can add the below code to your capabilities for testing internal servers on your network.
 
 `tunnel: true,`
 
-## Integrating Your Karma Testing Framework With LambdaTest
 
-To integrate Karma test runner with LambdaTest you need to set up LambdaTest authentication credentials **(access key & username)** as your environment variables in the ***karma.conf.js*** file.
+## Integrating Your Karma Testing Framework With TestMu AI
 
-**Test Scenario:** Check out this sample [karma.conf.js](https://github.com/LambdaTest/angular-karma-sample/blob/master/src/karma.conf.js) file for integrating Karma test runner with LambdaTest. You can use the sample file to test your own automation test suite by replacing the environment variables according to your need. 
+To integrate Karma test runner with TestMu AI you need to set up TestMu AI authentication credentials **(access key & username)** as your environment variables in the ***karma.conf.js*** file.
+
+**Test Scenario:** Check out this sample [karma.conf.js](https://github.com/LambdaTest/angular-karma-sample/blob/master/src/karma.conf.js) file for integrating Karma test runner with TestMu AI. You can use the sample file to test your own automation test suite by replacing the environment variables according to your need. 
 
 After declaring the required environment variable, comes the time to execute your test using the below command.
 
@@ -120,13 +124,14 @@ If you wish to use Jenkins, then [follow this documentation](/docs/jenkins-with-
 
 ### Parallel Testing
 
-Parallel testing is one of the most in-demand feature of LambdaTest Selenium Grid. By parallel testing, you can run more than one test case, simultaneously. This means that, parallel testing would allow you to execute numerous automation test cases altogether. So you execute a single test scenario across different browsers or could run different test scenarios across the same browser but with different browser versions.
+Parallel testing is one of the most in-demand feature of TestMu AI Selenium Grid. By parallel testing, you can run more than one test case, simultaneously. This means that, parallel testing would allow you to execute numerous automation test cases altogether. So you execute a single test scenario across different browsers or could run different test scenarios across the same browser but with different browser versions.
 
 To perform parallel testing, navigate to sample project “**angular-karma-sample**” and run the below command.
 
 `$ ng test`
 
-Monitor and analyze your test result ont the [LambdaTest Automation Dashboard](https://automation.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample).
+Monitor and analyze your test result ont the [TestMu AI Automation Dashboard](https://automation.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample).
+
 
 ## Avoid Timeouts With psuedoActivityInterval
 
@@ -142,50 +147,53 @@ customLaunchers: { chrome: {
 
 > **Note**: psuedoActivityInterval is presented as a default parameter with a value set to 0. Make sure to provide a value more than 0 in order to avoid the timeouts.
 
+
 ## Tutorials 📙
 
 Check out our latest tutorials on TestNG automation testing 👇
 
-* [Angular Testing With Jasmine And Karma Using Selenium [Tutorial]](https://www.lambdatest.com/blog/angular-testing-with-jasmine-and-karma/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample)
+* [Angular Testing With Jasmine And Karma Using Selenium [Tutorial]](https://www.testmuai.com/blog/angular-testing-with-jasmine-and-karma/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample)
+
 
 ## Documentation & Resources :books:
  
-Visit the following links to learn more about LambdaTest's features, setup and tutorials around test automation, mobile app testing, responsive testing, and manual testing.
+Visit the following links to learn more about TestMu AI's features, setup and tutorials around test automation, mobile app testing, responsive testing, and manual testing.
 
-* [LambdaTest Documentation](https://www.lambdatest.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample)
-* [LambdaTest Blog](https://www.lambdatest.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample)
-* [LambdaTest Learning Hub](https://www.lambdatest.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample)    
+* [TestMu AI Documentation](https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample)
+* [TestMu AI Blog](https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample)
+* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample)    
 
-## LambdaTest Community :busts_in_silhouette:
 
-The [LambdaTest Community](https://community.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample) allows people to interact with tech enthusiasts. Connect, ask questions, and learn from tech-savvy people. Discuss best practises in web development, testing, and DevOps with professionals from across the globe 🌎
+## TestMu AI Community :busts_in_silhouette:
 
-## What's New At LambdaTest ❓
+The [TestMu AI Community](https://community.testmuai.com/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample) allows people to interact with tech enthusiasts. Connect, ask questions, and learn from tech-savvy people. Discuss best practises in web development, testing, and DevOps with professionals from across the globe 🌎
 
-To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.lambdatest.com/) 
+
+## What's New At TestMu AI ❓
+
+To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.testmuai.com/) 
       
-## About LambdaTest
 
-[LambdaTest](https://www.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample) is a leading test execution and orchestration platform that is fast, reliable, scalable, and secure. It allows users to run both manual and automated testing of web and mobile apps across 3000+ different browsers, operating systems, and real device combinations. Using LambdaTest, businesses can ensure quicker developer feedback and hence achieve faster go to market. Over 500 enterprises and 1 Million + users across 130+ countries rely on LambdaTest for their testing needs.    
+## 🚀 [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/)
 
-### Features
+👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, LambdaTest has officially rebranded to TestMu AI. We have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
 
-* Run Selenium, Cypress, Puppeteer, Playwright, and Appium automation tests across 3000+ real desktop and mobile environments.
-* Real-time cross browser testing on 3000+ environments.
-* Test on Real device cloud
-* Blazing fast test automation with HyperExecute
-* Accelerate testing, shorten job times and get faster feedback on code changes with Test At Scale.
-* Smart Visual Regression Testing on cloud
-* 120+ third-party integrations with your favorite tool for CI/CD, Project Management, Codeless Automation, and more.
-* Automated Screenshot testing across multiple browsers in a single click.
-* Local testing of web and mobile apps.
-* Online Accessibility Testing across 3000+ desktop and mobile browsers, browser versions, and operating systems.
-* Geolocation testing of web and mobile apps across 53+ countries.
-* LT Browser - for responsive testing across 50+ pre-installed mobile, tablets, desktop, and laptop viewports
-    
-[<img height="58" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">](https://accounts.lambdatest.com/register)
-      
+Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
+
+**🔄 Our Rebrand Journey**
+
+We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
+
+**✨ Specialties**
+
+- 🤖 AI-Native Test Execution (Formerly LambdaTest)
+- ⚡ Autonomous Test Automation
+- 🌐 Cross-Browser & Mobile Testing
+- 📊 Unified Quality Intelligence
+
+👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
+
 ## We are here to help you :headphones:
 
-* Got a query? we are available 24x7 to help. [Contact Us](support@lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample)
-* For more info, visit - [LambdaTest](https://www.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample)
+* Got a query? we are available 24x7 to help. [Contact Us](support@testmuai.com/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample)
+* For more info, visit - [TestMu AI](https://www.testmuai.com/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample)

--- a/README.md
+++ b/README.md
@@ -180,13 +180,13 @@ To stay updated with the latest features and product add-ons, visit [Changelog](
 
 Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
-**🔄 Our Rebrand Journey**
+### 🔄 Our Rebrand Journey
 
 We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
 👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
 
-**🔭 Explore TestMu AI**
+### 🔭 Explore TestMu AI
 
 The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
 

--- a/README.md
+++ b/README.md
@@ -1,215 +1,130 @@
-# Run Selenium Tests With Karma Test Runner — TestMu AI (Formerly LambdaTest)
-
-![JavaScript](https://user-images.githubusercontent.com/95698164/172134732-2e9c780e-10ac-4956-b366-86ffc25bf070.png)
+# Run Angular Karma Tests with Selenium on TestMu AI (Formerly LambdaTest)
 
 <p align="center">
-  <a href="https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample" target="_bank">Blog</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample" target="_bank">Docs</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample" target="_bank">Learning Hub</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/newsletter/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample" target="_bank">Newsletter</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/certifications/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample" target="_bank">Certifications</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.youtube.com/@TestMuAI" target="_bank">YouTube</a>
+  <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
+  <a href="https://www.npmjs.com/package/karma"><img src="https://img.shields.io/npm/v/karma.svg?style=for-the-badge&labelColor=000000" alt="Karma version"></a>
+  <a href="https://community.testmuai.com/"><img src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&labelColor=000000" alt="Community"></a>
 </p>
-&emsp;
-&emsp;
-&emsp;
 
-*Learn how to use Karma Test Runner framework to configure and run your JavaScript automation testing scripts on the TestMu AI platform*
+## Getting Started
 
-[<img height="58" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">](https://accounts.lambdatest.com/register)
+[TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) lets you run Karma Test Runner with Selenium across 3000+ real browsers and operating systems. This sample shows how to configure Angular + Karma to run on the TestMu AI cloud.
 
+- [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
+- Follow the documentation on [Run Angular Karma tests with Selenium on TestMu AI](https://www.testmuai.com/support/docs/karma-integration-with-testmu/) (Formerly LambdaTest) for the full setup walkthrough.
 
-## Table Of Contents
+### Prerequisites
 
-* [Pre-requisites](#pre-requisites)
-* [Configuring TestMu AI tunnel To Run Karma Tests With TestMu AI](#configuring-lambdatest-tunnel-to-run-karma-tests-with-lambdatest)
-* [Integrating Your Karma Testing Framework With TestMu AI](#integrating-your-karma-testing-framework-with-lambdatest)
-* [Avoid Timeouts With psuedoActivityInterval](#avoid-timeouts-with-psuedoactivityinterval)
+- Node.js and npm (latest stable)
+- Angular CLI: `npm install -g @angular/cli`
+- A TestMu AI (Formerly LambdaTest) account with your username and access key
 
+### Setup
 
-## Pre-requisites
+Clone and install dependencies:
 
-In order to perform tests with TestMu AI using Karma testing framework, you would need the below things to be already set up:
-
-**1. Global Dependencies**
-* Make sure to use the latest version of JavaScript.
-* A Git or GitHub repository
-* Download and install node.js and node package manager or npm.
-To install node.js with homebrew use the below command.
-
-`$ brew install node`
-
-* If you have npm already installed, you may want to upgrade it to latest version. Here the code you can run in your terminal to upgrade npm.
-
-`npm install npm@latest -g`
-
-* Install [Angular CLI](https://cli.angular.io/)(Command Line Interface) with the below command.
-
-`$ npm install -g @angular/cli`
-
-
-**2. TestMu AI Authentication Credentials**
-
-Be aware of your TestMu AI authentication credentials i.e. your TestMu AI username, access key and HubURL. You need to set them up as your environment variables. You can retrieve them from your [TestMu AI automation dashboard](https://automation.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample) by clicking on the key icon near the help button.
-
-```
-Start tunnel with command from the configure tunnel in your dashboard
-this tunnel name will be needed to run the tests
-```
-* For Windows user:
 ```bash
-set LT_USERNAME=”YOUR_USERNAME”
-set LT_ACCESS_KEY=”YOUR ACCESS KEY”
-set LT_TUNNEL=”TUNNEL NAME”
+git clone https://github.com/LambdaTest/angular-karma-sample && cd angular-karma-sample
+npm install -g karma-cli && npm install
 ```
 
-* For macOS/Linux user:
+Set your credentials as environment variables.
+
+**macOS / Linux:**
+
 ```bash
-export LT_USERNAME=”YOUR_USERNAME”
-export LT_ACCESS_KEY=”YOUR ACCESS KEY”
-export LT_TUNNEL=”TUNNEL NAME”
+export LT_USERNAME="YOUR_USERNAME"
+export LT_ACCESS_KEY="YOUR_ACCESS_KEY"
+export LT_TUNNEL="YOUR_TUNNEL_NAME"
 ```
 
-### Setting Up
+**Windows:**
 
-Clone the sample project from TestMu AI GitHub repository by using the below command in your cmd/terminal.
+```bash
+set LT_USERNAME="YOUR_USERNAME"
+set LT_ACCESS_KEY="YOUR_ACCESS_KEY"
+set LT_TUNNEL="YOUR_TUNNEL_NAME"
+```
 
-`git clone https://github.com/LambdaTest/angular-karma-sample && cd angular-karma-sample`
+### Run tests
 
-Install the node.js dependencies and Karma CLI globally using the below command.
-
-`npm install -g karma-cli && npm install`
-
-> **Change Browsers & Framework For Sample Project:**
-> If you wish to add more browsers or change the framework to something other than the one used in our Sample project then you can do so by editing the browser array/ framework array in the *karma.conf.js* file.
-
-
-## Configuring TestMu AI tunnel To Run Karma Tests With TestMu AI
-
-To help you perform cross browser testing of your locally stored web pages, TestMu AI provides an SSH(Secure Shell) tunnel connection with the name TestMu AI tunnel. With TestMu AI tunnel, you can execute a test your local Karma tests on cloud for performing automated cross browser testing on more than 2000 browsers offered by Selenium Grid on TestMu AI. So you make sure how well your changes look, even before your customers. Curious to know more about TestMu AI tunnel?
-
-> Follow our documentation on TestMu AI tunnel to know it all. OS specific instructions to download and setup tunnel binary can be found at the following links.
- * [Documentation For Windows User](/docs/local-testing-for-windows/)
- * [Documentation For Mac User](/docs/local-testing-for-macos/)
- * [Documentation For Linux User](/docs/local-testing-for-linux/)
-
-> Download the binary file of:
- * [TestMu AI tunnel for Windows](https://downloads.lambdatest.com/tunnel/v3/windows/64bit/LT_Windows.zip)
- * [TestMu AI tunnel for Mac](https://downloads.lambdatest.com/tunnel/v3/mac/64bit/LT_Mac.zip)
- * [TestMu AI tunnel for Linux](https://downloads.lambdatest.com/tunnel/v3/linux/64bit/LT_Linux.zip)
-
-Once, the tunnel is successfully set up. You can add the below code to your capabilities for testing internal servers on your network.
-
-`tunnel: true,`
-
-
-## Integrating Your Karma Testing Framework With TestMu AI
-
-To integrate Karma test runner with TestMu AI you need to set up TestMu AI authentication credentials **(access key & username)** as your environment variables in the ***karma.conf.js*** file.
-
-**Test Scenario:** Check out this sample [karma.conf.js](https://github.com/LambdaTest/angular-karma-sample/blob/master/src/karma.conf.js) file for integrating Karma test runner with TestMu AI. You can use the sample file to test your own automation test suite by replacing the environment variables according to your need. 
-
-After declaring the required environment variable, comes the time to execute your test using the below command.
-
+```bash
 karma start karma.conf.js
-
-`karma start karma.conf.js`
-
-If you wish to use Jenkins, then [follow this documentation](/docs/jenkins-with-lambdatest/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample).
-
-### Parallel Testing
-
-Parallel testing is one of the most in-demand feature of TestMu AI Selenium Grid. By parallel testing, you can run more than one test case, simultaneously. This means that, parallel testing would allow you to execute numerous automation test cases altogether. So you execute a single test scenario across different browsers or could run different test scenarios across the same browser but with different browser versions.
-
-To perform parallel testing, navigate to sample project “**angular-karma-sample**” and run the below command.
-
-`$ ng test`
-
-Monitor and analyze your test result ont the [TestMu AI Automation Dashboard](https://automation.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample).
-
-
-## Avoid Timeouts With psuedoActivityInterval
-
-To make sure our machines are not hold for long due to some incorrect test, we have come up with a restriction on the number of seconds that our machine is kept reserved for you. In cases, where our servers fail to retrieve a request from your local machine for more than 90 seconds, then your tests are aborted from the queue with the error message related to Timeouts.
-
-If you wish to avoid such timeouts, you need to make use of the below parameter:
-
-``` js
-customLaunchers: { chrome: {
- pseudoActivityInterval: 5000 // 5000 ms heartbeat to avoid timeouts
- } }
 ```
 
-> **Note**: psuedoActivityInterval is presented as a default parameter with a value set to 0. Make sure to provide a value more than 0 in order to avoid the timeouts.
+For parallel execution across browsers:
 
+```bash
+ng test
+```
 
-## Tutorials 📙
+View results on your TestMu AI dashboard.
 
-Check out our latest tutorials on TestNG automation testing 👇
+### Local testing with TestMu AI Tunnel
 
-* [Angular Testing With Jasmine And Karma Using Selenium [Tutorial]](https://www.testmuai.com/blog/angular-testing-with-jasmine-and-karma/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample)
+To test locally hosted apps, set up the TestMu AI tunnel. OS-specific guides:
 
+- [Local Testing on Windows](https://www.testmuai.com/support/docs/local-testing-for-windows/)
+- [Local Testing on macOS](https://www.testmuai.com/support/docs/local-testing-for-macos/)
+- [Local Testing on Linux](https://www.testmuai.com/support/docs/local-testing-for-linux/)
 
-## Documentation & Resources :books:
- 
-Visit the following links to learn more about TestMu AI's features, setup and tutorials around test automation, mobile app testing, responsive testing, and manual testing.
+Add the following to your capabilities:
 
-* [TestMu AI Documentation](https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample)
-* [TestMu AI Blog](https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample)
-* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample)    
+```js
+tunnel: true,
+```
 
+### Avoid timeouts with `pseudoActivityInterval`
 
-## TestMu AI Community :busts_in_silhouette:
+TestMu AI aborts test sessions if the machine is held idle for 90+ seconds. To keep sessions alive, send a heartbeat:
 
-The [TestMu AI Community](https://community.testmuai.com/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample) allows people to interact with tech enthusiasts. Connect, ask questions, and learn from tech-savvy people. Discuss best practises in web development, testing, and DevOps with professionals from across the globe 🌎
+```js
+customLaunchers: {
+  chrome: {
+    pseudoActivityInterval: 5000 // 5s heartbeat
+  }
+}
+```
 
+The default is `0` (disabled). Set any value above `0` to enable.
 
-## What's New At TestMu AI ❓
+## TestMu AI (Formerly LambdaTest) Community
 
-To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.testmuai.com/) 
-      
+Connect with testers and developers in the [TestMu AI Community](https://community.testmuai.com/). Ask questions, share what you are building, and discuss best practices in test automation and DevOps.
+  
+## TestMu AI (Formerly LambdaTest) Certifications
 
-## 🚀 LambdaTest is Now TestMu AI
+Earn free [TestMu AI Certifications](https://www.testmuai.com/certifications/) for testers, developers, and QA engineers. Validate your skills in Selenium, Cypress, Playwright, Appium, Espresso and more. Industry-recognized, shareable on LinkedIn, and built by practitioners, not marketers.
 
-👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/) - we have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
+## Learning Resources by TestMu AI (Formerly LambdaTest)
 
-Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
+Learn modern testing through tutorials, guides, videos, and weekly updates:
 
-### 🔄 Our Rebrand Journey
+* [TestMu AI Blog](https://www.testmuai.com/blog/) - Tutorials, deep dives, and framework guides for testers and developers.
+* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/) - Long-form learning paths on Selenium, Cypress, Playwright, Appium, and AI-native testing.
+* [TestMu AI Newsletter](https://www.testmuai.com/newsletter/) - Weekly roundup of what's new in testing, dev tools, and AI.
+* [TestMu AI on YouTube](https://www.youtube.com/@TestMuAI) - Walkthroughs, product demos, and talks from TestMu Conference.
 
-In 2017, we introduced LambdaTest with a clear mission: to become the world's most trusted cloud testing platform. We built a scalable, high-performance test cloud that eliminated flakiness, improved developer feedback cycles, and accelerated release velocity for teams worldwide.
+## Contributions
 
-As LambdaTest grew, we expanded the platform into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the entire testing lifecycle. These capabilities enabled teams to test any stack, on any technology, at enterprise scale.
+Contributions are welcome. Open an issue to discuss your idea before submitting a pull request. When reporting bugs, include your Node.js version, OS, and Angular CLI version.
 
-Over time, we rebuilt the architecture to be AI-native from the ground up. What began as LambdaTest's high-performance testing cloud has now evolved into TestMu AI, an AI-native, multi-agent platform redefining modern quality engineering.
+## LambdaTest is Now TestMu AI
 
-In 2017, we introduced LambdaTest with a clear mission: to become the world's most trusted cloud testing platform. We built a scalable, high-performance test cloud that eliminated flakiness, improved developer feedback cycles, and accelerated release velocity for teams worldwide.
+On **January 12, 2026**, [LambdaTest evolved to TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/), the world's first fully autonomous **Agentic AI Quality Engineering Platform**.
 
-As LambdaTest grew, we expanded the platform into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the entire testing lifecycle. These capabilities enabled teams to test any stack, on any technology, at enterprise scale.
+Same team. Same infrastructure. Same customer accounts. All existing LambdaTest logins, scripts, capabilities, and integrations continue to work without change.
 
-Over time, we rebuilt the architecture to be AI-native from the ground up. What began as LambdaTest's high-performance testing cloud has now evolved into TestMu AI, an AI-native, multi-agent platform redefining modern quality engineering.
+👉 Find the new home for [LambdaTest](https://www.testmuai.com).
 
-We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
+### How LambdaTest Evolved into TestMu AI
 
-👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
+In 2017, we launched LambdaTest with a simple mission: make testing fast, reliable, and accessible. As LambdaTest grew, we expanded into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the full depth of the testing lifecycle.
 
-### 🔭 Explore TestMu AI
+As software development entered the AI era, testing had to evolve, too. We rebuilt the architecture to be AI-native from the ground up, with autonomous agents that **plan, author, execute, analyze, and optimize tests** while keeping humans in the loop. The platform integrates with your repos, CI, IDEs, and terminals, continuously learning from every code change and development signal.
 
-The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
+That evolution earned a new name: **TestMu AI**, built for an AI-first future of quality engineering. TestMu is not a new name for us. It is the name of our annual community conference, which has brought together 100,000+ quality engineers to discuss how AI would reshape testing, long before that became an industry norm. TestMu AI reflects our commitment to community-driven innovation and AI-native architecture.
 
-- [KaneAI](https://www.testmuai.com/kane-ai/)
-- [Agent-to-Agent Testing](https://www.testmuai.com/agent-to-agent-testing/)
-- [HyperExecute](https://www.testmuai.com/hyperexecute/)
-- [Real Device Cloud](https://www.testmuai.com/real-device-cloud/)
-- [Pricing](https://www.testmuai.com/pricing/)
-- [Documentation](https://www.testmuai.com/support/docs/)
+## Support
 
-## We are here to help you :headphones:
-
-* Got a query? we are available 24x7 to help. [Contact Us](support@testmuai.com/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample)
-* For more info, visit - [TestMu AI](https://www.testmuai.com/?utm_source=github&utm_medium=repo&utm_campaign=angular-karma-sample)
+Got a question? Email [support@testmuai.com](mailto:support@testmuai.com) or chat with us 24x7 from our chat portal.

--- a/README.md
+++ b/README.md
@@ -174,9 +174,9 @@ The [TestMu AI Community](https://community.testmuai.com/?utm_source=github&utm_
 To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.testmuai.com/) 
       
 
-## 🚀 [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/)
+## 🚀 LambdaTest is Now TestMu AI
 
-👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, LambdaTest has officially rebranded to TestMu AI. We have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
+👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/) - we have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
 
 Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,12 @@ Whether you have been part of the LambdaTest community for years or are just dis
 
 ### 🔄 Our Rebrand Journey
 
+In 2017, we introduced LambdaTest with a clear mission: to become the world's most trusted cloud testing platform. We built a scalable, high-performance test cloud that eliminated flakiness, improved developer feedback cycles, and accelerated release velocity for teams worldwide.
+
+As LambdaTest grew, we expanded the platform into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the entire testing lifecycle. These capabilities enabled teams to test any stack, on any technology, at enterprise scale.
+
+Over time, we rebuilt the architecture to be AI-native from the ground up. What began as LambdaTest's high-performance testing cloud has now evolved into TestMu AI, an AI-native, multi-agent platform redefining modern quality engineering.
+
 We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
 👉 Find [LambdaTest's New Home](https://www.testmuai.com/).

--- a/README.md
+++ b/README.md
@@ -184,12 +184,16 @@ Whether you have been part of the LambdaTest community for years or are just dis
 
 We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
-**✨ Specialties**
+**Explore TestMu AI**
 
-- 🤖 AI-Native Test Execution (Formerly LambdaTest)
-- ⚡ Autonomous Test Automation
-- 🌐 Cross-Browser & Mobile Testing
-- 📊 Unified Quality Intelligence
+The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
+
+- [KaneAI](https://www.testmuai.com/kane-ai/)
+- [Agent-to-Agent Testing](https://www.testmuai.com/agent-to-agent-testing/)
+- [HyperExecute](https://www.testmuai.com/hyperexecute/)
+- [Real Device Cloud](https://www.testmuai.com/real-device-cloud/)
+- [Pricing](https://www.testmuai.com/pricing/)
+- [Documentation](https://www.testmuai.com/support/docs/)
 
 👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,12 @@ As LambdaTest grew, we expanded the platform into Test Intelligence, Visual Regr
 
 Over time, we rebuilt the architecture to be AI-native from the ground up. What began as LambdaTest's high-performance testing cloud has now evolved into TestMu AI, an AI-native, multi-agent platform redefining modern quality engineering.
 
+In 2017, we introduced LambdaTest with a clear mission: to become the world's most trusted cloud testing platform. We built a scalable, high-performance test cloud that eliminated flakiness, improved developer feedback cycles, and accelerated release velocity for teams worldwide.
+
+As LambdaTest grew, we expanded the platform into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the entire testing lifecycle. These capabilities enabled teams to test any stack, on any technology, at enterprise scale.
+
+Over time, we rebuilt the architecture to be AI-native from the ground up. What began as LambdaTest's high-performance testing cloud has now evolved into TestMu AI, an AI-native, multi-agent platform redefining modern quality engineering.
+
 We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
 👉 Find [LambdaTest's New Home](https://www.testmuai.com/).


### PR DESCRIPTION
## Summary
- Replaced all LambdaTest references with TestMu AI in prose and links
- Updated H1 heading: Run Selenium Tests With Karma Test Runner -- TestMu AI (Formerly LambdaTest)
- Added LambdaTest is Now TestMu AI rebrand section
- Updated YouTube link to @TestMuAI and community URL to testmuai.com

## Test plan
- Preview README renders correctly on GitHub
- All links return 200
- No LambdaTest branding remaining in prose

Generated with Claude Code